### PR TITLE
fix(deploy): Adjust gunicorn command for src layout on Render

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,6 @@ USER app
 RUN pip install --user --upgrade pip && \
     pip install --user --no-cache-dir -r requirements-dev.txt
 
-CMD ["gunicorn", "--bind", "0.0.0.0:8000", "--chdir", "src", "project.wsgi:application"]
+WORKDIR /workspace/src
+
+CMD ["gunicorn", "--bind", "0.0.0.0:8000", "project.wsgi:application"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,4 @@ USER app
 RUN pip install --user --upgrade pip && \
     pip install --user --no-cache-dir -r requirements-dev.txt
 
-WORKDIR /workspace/src
-
-CMD ["gunicorn", "--bind", "0.0.0.0:8000", "project.wsgi:application"]
+CMD ["gunicorn", "--bind", "0.0.0.0:8000", "src.project.wsgi:application"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,10 @@ USER app
 RUN pip install --user --upgrade pip && \
     pip install --user --no-cache-dir -r requirements-dev.txt
 
+USER root
+
+COPY --chown=app:app . .
+
+USER app
+
 CMD ["gunicorn", "--bind", "0.0.0.0:8000", "src.project.wsgi:application"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ USER app
 RUN pip install --user --upgrade pip && \
     pip install --user --no-cache-dir -r requirements-dev.txt
 
-CMD ["gunicorn", "--bind", "0.0.0.0:8000", "src.project.wsgi:application"]
+CMD ["gunicorn", "--bind", "0.0.0.0:8000", "--chdir", "src", "project.wsgi:application"]


### PR DESCRIPTION
## What's New

-   This PR modifies the `CMD` instruction in the `Dockerfile`.
-   It uses the `--chdir` flag in the `gunicorn` command to correctly point to the `src` directory before starting the application.

## Why

-   The previous deployment on Render failed with a `ModuleNotFoundError: No module named 'src'`.
-   This happened because the Gunicorn production server was not aware of the project's `src` layout, unlike the local development environment.
-   This fix explicitly tells Gunicorn to change its working directory to `src` before trying to import the `project.wsgi` module, resolving the import error.

## Testing

-   [x]  Confirm that a manual deploy on Render using this branch (`fix/render-deploy-command`) completes successfully with a "Live" status.